### PR TITLE
fix: Adding logic to handle both new deployments and updates

### DIFF
--- a/.github/workflows/backend-deployment.yml
+++ b/.github/workflows/backend-deployment.yml
@@ -75,4 +75,11 @@ jobs:
           pm2 --version
 
       - name: Run api with pm2
-        run: cd apps/api && pm2 restart pnpm --name "signalicon-api" -- start
+        run: |
+          cd apps/api
+          pm2 describe "signalicon-api" > /dev/null
+          if [ $? -eq 0 ]; then
+            pm2 restart "signalicon-api"
+          else
+            pm2 start pnpm --name "signalicon-api" -- start
+          fi


### PR DESCRIPTION
This script will:
Check if the process already exists
If it exists, restart it
If it doesn't exist, start it for the first time